### PR TITLE
Quick fix on service name to run on dlaas services

### DIFF
--- a/service/lcm/constants.go
+++ b/service/lcm/constants.go
@@ -83,16 +83,16 @@ const (
 const (
 	//Total CPU for helpers = 2.5
 	//Total RAM for helpers = 4 GB
-	storeResultsMilliCPU=20
-	storeResultsMemInMB=100
-	loadModelMilliCPU=20
-	loadModelMemInMB=50
-	loadTrainingDataMilliCPU=20
-	loadTrainingDataMemInMB=100
-	logCollectorMilliCPU=20
-	logCollectorMemInMB=100
-	controllerMilliCPU=20
-	controllerMemInMB=100
+	storeResultsMilliCPU=100
+	storeResultsMemInMB=500
+	loadModelMilliCPU=100
+	loadModelMemInMB=500
+	loadTrainingDataMilliCPU=100
+	loadTrainingDataMemInMB=500
+	logCollectorMilliCPU=100
+	logCollectorMemInMB=500
+	controllerMilliCPU=100
+	controllerMemInMB=500
 )
 
 const (

--- a/service/lcm/container_helper.go
+++ b/service/lcm/container_helper.go
@@ -22,6 +22,7 @@ import (
 	"path"
 	"strings"
 	"text/template"
+	"os"
 
 	"github.com/AISphere/ffdl-commons/config"
 	"github.com/AISphere/ffdl-commons/service"
@@ -209,11 +210,11 @@ func fetchImageNameFromEvaluationMetrics(evalMetricsString string,
 }
 
 func findTrainingDataServiceTag(k8sClient kubernetes.Interface, logr *logger.LocLoggingEntry) string {
-	selector := "service==ffdl-trainingdata"
+	selector := "service==" + os.Getenv("DATA_SERVICE_NAME")
 	podInterface := k8sClient.Core().Pods(config.GetPodNamespace())
 	pods, err := podInterface.List(metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
-		logr.WithError(err).Debugf("Could not find service=ffdl-trainingdata")
+		logr.WithError(err).Debugf("Could not find service=%s", os.Getenv("DATA_SERVICE_NAME"))
 		// bad fallback, ideally should never happen
 		return logCollectorBadTagNoTDSFound
 	}
@@ -465,7 +466,7 @@ func constructLearnerContainer(req *service.JobDeploymentRequest, envVars []v1co
 	}
 
 	learnerContainer := learner.CreateContainerSpec(container)
-	extendLearnerContainer(&learnerContainer, req, logr)
+	//extendLearnerContainer(&learnerContainer, req, logr)
 	return learnerContainer
 }
 

--- a/trainer-client/client.go
+++ b/trainer-client/client.go
@@ -19,6 +19,7 @@ package client
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/AISphere/ffdl-commons/config"
 	"github.com/AISphere/ffdl-commons/util"
@@ -57,7 +58,7 @@ func NewTrainer() (TrainerClient, error) {
 // service. If the dns_server config option is set to 'disabled', it will
 // default to the pre-defined LocalPort of the service.
 func NewTrainerWithAddress(addr string) (TrainerClient, error) {
-	address := fmt.Sprintf("ffdl-trainer.%s.svc.cluster.local:80", config.GetPodNamespace())
+	address := fmt.Sprintf("%s.%s.svc.cluster.local:80", os.Getenv("TRAINER_SERVICE_NAME"), config.GetPodNamespace())
 	dnsServer := viper.GetString("dns_server")
 	if dnsServer == disabled { // for local testing without DNS server
 		address = addr


### PR DESCRIPTION
This PR will read the hard-coded services name from environment variables. Thus, in order to use it in DLaaS, we need to add the following env to the lcm deployment yaml on Kubernetes.
```yaml
        - name: TRAINER_SERVICE_NAME
          value: dlaas-trainer-v2
        - name: DATA_SERVICE_NAME
          value: dlaas-training-data
```
 
Also, I commented out the `extendLearnerContainer` function for now because it's not compatible to run on DLaaS. 

More note: Fixing the evaluation metrics bug is still in progress.



Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

