### PR TITLE
Minor changes to allow LCM to use custom images without register credentials

### DIFF
--- a/service/lcm/learner/imagesecrets.go
+++ b/service/lcm/learner/imagesecrets.go
@@ -19,7 +19,6 @@ package learner
 import (
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 
 	"github.com/spf13/viper"
 	"github.com/AISphere/ffdl-commons/config"
@@ -50,9 +49,9 @@ func GenerateImagePullSecret(k8sClient kubernetes.Interface, req *service.JobDep
 		}, nil
 	}
 
-	// if no token specified, then use ours
+	// if no token specified, do not use a pull secret
 	if req.ImageLocation.AccessToken == "" {
-		return []v1core.LocalObjectReference{}, errors.New("Custom image access token is missing")
+		return []v1core.LocalObjectReference{}, nil
 	}
 
 	// build a custom secret


### PR DESCRIPTION
Currently by default, LCM only allows BYO containers to be pulled with register credentials. Which is not necessary for public image registry such as docker.io and quay.io. Therefore, this PR will make LCM ignore the null AccessToken error and proceed with pulling the images without any register credentials.

With this, LCM should able to pull community images and train it as in FfDL with minor changes on the manifest.yml. (We still need to discuss on how to embedding entrypoint train.sh script for community images that use MPI distributed training.) 

Note: BYO currently only works with GRPC because the RestAPI did not implement with the BYO feature. 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

